### PR TITLE
fix: add canonical URLs for nested note routes

### DIFF
--- a/src/app/notes/[seasonSlug]/[episodeSlug]/[pageSlug]/page.tsx
+++ b/src/app/notes/[seasonSlug]/[episodeSlug]/[pageSlug]/page.tsx
@@ -45,6 +45,9 @@ export async function generateMetadata({ params }: PageRouteProps): Promise<Meta
   return {
     title,
     description,
+    alternates: {
+      canonical: `/notes/${seasonSlug}/${episodeSlug}/${pageSlug}`,
+    },
     openGraph: {
       title,
       description,

--- a/src/app/notes/[seasonSlug]/[episodeSlug]/page.tsx
+++ b/src/app/notes/[seasonSlug]/[episodeSlug]/page.tsx
@@ -32,6 +32,9 @@ export async function generateMetadata({ params }: EpisodePageProps): Promise<Me
   return {
     title,
     description: episode.description,
+    alternates: {
+      canonical: `/notes/${seasonSlug}/${episodeSlug}`,
+    },
     openGraph: {
       title,
       description: episode.description,

--- a/src/app/notes/[seasonSlug]/page.tsx
+++ b/src/app/notes/[seasonSlug]/page.tsx
@@ -24,6 +24,9 @@ export async function generateMetadata({ params }: SeasonPageProps): Promise<Met
   return {
     title: `Season ${season.seasonNumber}: ${season.title} — Namaste AI Notes`,
     description: season.description,
+    alternates: {
+      canonical: `/notes/${seasonSlug}`,
+    },
     openGraph: {
       title: `Season ${season.seasonNumber}: ${season.title} — Namaste AI Notes`,
       description: season.description,


### PR DESCRIPTION
## Summary

Adds explicit canonical URLs for nested notes routes.

Previously, the root layout defined `/` as the canonical URL, while season, episode, and individual note pages did not override it. Since Next.js metadata is inherited by nested routes, those pages could incorrectly advertise the homepage as their canonical URL.

## Changes

* Add canonical URL for season pages
* Add canonical URL for episode pages
* Add canonical URL for individual note pages

Examples now resolve correctly to:

* `/notes/season-1`
* `/notes/season-1/episode-2-the-evolution-of-ai`
* `/notes/season-1/episode-2-the-evolution-of-ai/machine-learning`

## Why this matters

Correct canonical URLs help search engines understand which URL represents each page and avoid treating valid note pages as duplicates of the homepage.

## Scope

This PR only updates route metadata and does not change page rendering or navigation behavior.
