### PR TITLE
fix: handle unavailable localStorage in theme provider

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -82,6 +82,9 @@ export function ThemeProvider({ children }: Readonly<{ children: ReactNode }>) {
       if (isTheme(savedTheme)) {
         setThemeState(savedTheme);
       }
+    } catch {
+      // Storage can be unavailable in restricted/privacy-focused browser contexts.
+      // Keep the default theme instead of letting theme initialization fail.
     } finally {
       setIsThemeLoaded(true);
     }
@@ -95,7 +98,12 @@ export function ThemeProvider({ children }: Readonly<{ children: ReactNode }>) {
     const root = document.documentElement;
     root.dataset.theme = theme;
     root.classList.toggle("dark", theme === "dark");
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Applying the theme should not depend on persistent storage being writable.
+    }
   }, [isThemeLoaded, theme]);
 
   const setTheme = useCallback((nextTheme: Theme) => {


### PR DESCRIPTION
## Summary

Makes theme persistence more resilient when `localStorage` is unavailable or throws an exception.

Previously, failures while reading or writing the saved theme could propagate and potentially interrupt theme initialization.

## Changes

* Gracefully handle failures when reading the saved theme
* Gracefully handle failures when persisting theme changes
* Preserve the existing default theme when storage is unavailable
* Keep normal theme behavior unchanged when `localStorage` works normally

## Why this matters

Browser storage may be unavailable in some privacy-restricted, sandboxed, or unusual browser environments. Theme persistence should remain optional and should not cause a runtime failure.

## Scope

This PR only affects theme persistence error handling and does not change the visual theme behavior or storage key.